### PR TITLE
Cubeb master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ cmake = "0.1"
 pkg-config = "0.3"
 
 [dependencies]
-libc="*"
+libc = "*"
+bitflags = "0.9"
 heapsize = {version = ">=0.2, <0.4", optional = true}
 heapsize_plugin = {version = "0.1.0", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,9 @@ build-cubeb = []
 plugins = ["heapsize", "heapsize_plugin"]
 
 [build-dependencies]
-pkg-config = "0.3.5"
-submodules = "0.1.0"
+submodules = "0.1"
+cmake = "0.1"
+pkg-config = "0.3"
 
 [dependencies]
 libc="*"

--- a/build.rs
+++ b/build.rs
@@ -2,18 +2,9 @@ extern crate pkg_config;
 extern crate submodules;
 extern crate cmake;
 
-use std::process::Command;
 use std::io::{BufRead, BufReader};
 use std::fs::File;
 use std::env;
-
-fn check_command(cmd: &str) -> bool {
-  return Command::new("which").arg(cmd)
-                              .status()
-                              .unwrap_or_else(|e| {
-    panic!("Failed to execute command: {}", e)
-  }).success();
-}
 
 fn parse_cubeb_cache(cache: String) -> String {
   let file = File::open(cache.clone()).unwrap_or_else(|e| {
@@ -70,10 +61,6 @@ fn main()
     println!("cargo:rustc-link-lib=dylib=cubeb");
     return
   }
-
-  let out_dir = env::var("OUT_DIR").unwrap();
-  let cubeb_src_dir = "cubeb";
-  let cubeb_build_dir = "cubeb-build";
 
   submodules::update().init().recursive().run();
 

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 extern crate pkg_config;
 extern crate submodules;
+extern crate cmake;
 
 use std::process::Command;
 use std::io::{BufRead, BufReader};
@@ -14,9 +15,9 @@ fn check_command(cmd: &str) -> bool {
   }).success();
 }
 
-fn parse_cubeb_config_h(config_h: &str) -> String {
-  let file = File::open(config_h).unwrap_or_else(|e| {
-    panic!("Failed to open config.h: {}", e);
+fn parse_cubeb_cache(cache: String) -> String {
+  let file = File::open(cache.clone()).unwrap_or_else(|e| {
+    panic!("Failed to open {}: {}", cache, e);
   });
   let mut reader = BufReader::new(file);
   let mut line = String::new();
@@ -24,32 +25,26 @@ fn parse_cubeb_config_h(config_h: &str) -> String {
 
   while reader.read_line(&mut line).unwrap() > 0 {
     {
-      let l = line.trim();
-      if l.starts_with("#define") {
-        match &l[8..] {
-          "HAVE_ALSA_ASOUNDLIB_H 1" => {
-            flags.push_str("cargo:rustc-link-lib=asound\n");
-          },
-          "HAVE_AUDIOUNIT_AUDIOUNIT_H 1" => {
-            flags.push_str("cargo:rustc-link-lib=framework=AudioUnit\n");
-          },
-          "HAVE_DSOUND_H 1" => {
-            flags.push_str("cargo:rustc-link-lib=dsound\n");
-          },
-          "HAVE_PULSE_PULSEAUDIO_H 1" => {
-            flags.push_str("cargo:rustc-link-lib=pulse\n");
-          },
-          "HAVE_SLES_OPENSLES_H 1" => {
-            flags.push_str("cargo:rustc-link-lib=OpenSLES\n");
-          },
-          "HAVE_SNDIO_H 1" => {
-            flags.push_str("cargo:rustc-link-lib=sndio\n");
-          },
-          "HAVE_WINDOWS_H 1" => {
-            flags.push_str("cargo:rustc-link-lib=winmm\n");
-          },
-          _ => {}
-        }
+      if line.contains("USE_ALSA:INTERNAL=1") {
+        flags.push_str("cargo:rustc-link-lib=asound\n");
+      }
+      else if line.contains("USE_AUDIOUNIT:INTERNAL=1") {
+        flags.push_str("cargo:rustc-link-lib=framework=AudioUnit\n");
+      }
+      else if line.contains("USE_JACK:INTERNAL=1") {
+        flags.push_str("cargo:rustc-link-lib=jack\n");
+      }
+      else if line.contains("USE_OPENSL:INTERNAL=1") {
+        flags.push_str("cargo:rustc-link-lib=OpenSLES\n");
+      }
+      else if line.contains("USE_PULSE:INTERNAL=1") {
+        flags.push_str("cargo:rustc-link-lib=pulse\n");
+      }
+      else if line.contains("USE_SNDIO:INTERNAL=1") {
+        flags.push_str("cargo:rustc-link-lib=sndio\n");
+      }
+      else if line.contains("USE_WINMM:INTERNAL=1") {
+        flags.push_str("cargo:rustc-link-lib=winmm\n");
       }
     }
     line.clear();
@@ -77,38 +72,15 @@ fn main()
   }
 
   let out_dir = env::var("OUT_DIR").unwrap();
+  let cubeb_src_dir = "cubeb";
+  let cubeb_build_dir = "cubeb-build";
 
-  let cubeb_dir = "cubeb";
+  submodules::update().init().recursive().run();
 
-  submodules::update().init().run();
+  let dst = cmake::build("cubeb");
 
-  assert!(check_command("autoreconf"), "autoreconf missing!");
-  assert!(check_command("automake"), "automake missing!");
-  assert!(check_command("pkg-config"), "pkg-config missing!");
-  assert!(check_command("libtool"), "libtool missing!");
-
-  assert!(env::set_current_dir(cubeb_dir).is_ok());
-
-  assert!(Command::new("autoreconf").arg("--install")
-                                    .status()
-                                    .unwrap_or_else(|e| {
-    panic!("Failed to execute command: {}", e);
-  }).success(), "autoreconf exited with an error.");
-
-  assert!(Command::new("./configure").args(&["--host", &target])
-                                     .args(&["--prefix", &out_dir])
-                                     .status()
-                                     .unwrap_or_else(|e| {
-    panic!("Failed to execute command: {}", e);
-  }).success(), "./configure exited with an error.");
-
-  assert!(Command::new("make").arg("install")
-                              .status()
-                              .unwrap_or_else(|e| {
-    panic!("Failed to execute command: {}", e);
-  }).success(), "make exited with an error.");
-
-  println!("cargo:rustc-link-search=native={}/lib", out_dir);
+  println!("cargo:rustc-link-search=native={}", dst.display());
   println!("cargo:rustc-link-lib=static=cubeb");
-  print!("{}", parse_cubeb_config_h("config.h"));
+  println!("cargo:rustc-flags=-l dylib=stdc++");
+  print!("{}", parse_cubeb_cache(format!("{}/build/CMakeCache.txt", dst.display())));
 }

--- a/examples/list_devices.rs
+++ b/examples/list_devices.rs
@@ -1,0 +1,32 @@
+
+extern crate cult;
+
+fn list_devices(ctx: &cult::Context, dt: cult::DeviceType) {
+    let devices = ctx.enumerate_devices(dt)
+            .expect(&format!("Cult could not enumerate {:?} devices", dt));
+    println!("{:?} devices:", dt);
+    for dev in devices {
+        println!("  {}:", dev.device_id());
+        println!("    devid:          {:p}", dev.devid());
+        println!("    name:           {}", dev.friendly_name());
+        println!("    group id:       {}", dev.group_id());
+        println!("    vendor:         {}", dev.vendor_name());
+        println!("    type:           {:?}", dev.device_type());
+        println!("    state:          {:?}", dev.state());
+        println!("    pref:           {:?}", dev.preferred());
+        println!("    format:         {:?}", dev.format());
+        println!("    default format: {:?}", dev.default_format());
+        println!("    max channels:   {}", dev.max_channels());
+        println!("    default rate:   {}", dev.default_rate());
+        println!("    max rate:       {}", dev.max_rate());
+        println!("    min rate:       {}", dev.min_rate());
+        println!("    latency low:    {}", dev.latency_lo());
+        println!("    latency high:   {}", dev.latency_hi());
+    }
+}
+
+fn main() {
+    let ctx = cult::Context::new("", None).unwrap();
+    list_devices(&ctx, cult::DeviceType::Input);
+    list_devices(&ctx, cult::DeviceType::Output);
+}

--- a/examples/playthrough.rs
+++ b/examples/playthrough.rs
@@ -1,0 +1,37 @@
+
+extern crate cult;
+
+use std::{thread, time};
+
+// 5 seconds of play through
+
+const SAMPLE_RATE: f32 = 44100_f32;
+
+
+fn main() {
+    let ctx = cult::Context::new("Playthrough example", None).unwrap();
+
+    println!("context open with {} backend", ctx.backend_id());
+
+    let cb: cult::DataCallback<f32> = Box::new(move |ib: &[f32], ob: &mut [f32]| {
+        for s in 0 .. ob.len() {
+            ob[s] = ib[s];
+        }
+        ob.len()
+    });
+
+    let params = cult::StreamParams::<f32>::new(SAMPLE_RATE as u32, 1, cult::ChannelLayout::Mono);
+    let min_latency = ctx.min_latency(params).expect("could not retrieve minimum latency");
+
+    let stm = cult::Stream::<f32>::new(
+        &ctx, "Playthrough",
+        None, Some(params), None, Some(params),
+        min_latency, cb, Some(Box::new(cult::print_state_change))
+    ).expect("could not create audio stream");
+
+    stm.start().unwrap();
+
+    thread::sleep(time::Duration::from_millis(5000));
+
+    stm.stop().unwrap();
+}

--- a/examples/ring_tone.rs
+++ b/examples/ring_tone.rs
@@ -1,0 +1,108 @@
+
+extern crate cult;
+
+use std::{thread, time};
+
+// Japanese tone: 400 Hz tone with amplitude modulation of 20 Hz.
+// 1 sec tone with 2 sec pause
+// smoothstep is used to avoid glitches
+
+const SAMPLE_RATE: f32 = 44100_f32;
+const STEP_LEN: f32 = 0.050_f32;
+
+fn smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {
+    let x = clamp((x - edge0)/(edge1 - edge0), 0_f32, 1_f32);
+    x*x*(3_f32 - x*2_f32)
+}
+
+fn clamp(x: f32, low: f32, high: f32) -> f32 {
+    if x < low { low }
+    else if x > high { high }
+    else { x }
+}
+
+fn main() {
+    let ctx = cult::Context::new("Tone example", None).unwrap();
+
+    println!("context open with {} backend", ctx.backend_id());
+
+    let phase_pulse = std::f32::consts::PI * 2_f32 * 400_f32 / SAMPLE_RATE;
+    let mod_phase_pulse = std::f32::consts::PI * 2_f32 * 20_f32 / SAMPLE_RATE;
+
+    #[derive(Debug, Copy, Clone)]
+    struct State {
+        phase: f32,         // rad
+        mod_phase: f32,     // rad
+        tone_phase: f32,    // sec
+    }
+    let mut state = Box::new(State {
+        phase: 0_f32, mod_phase: 0_f32, tone_phase: 0_f32
+    });
+
+    let cb: cult::DataCallback<f32> = Box::new(move |_: &[f32], outp: &mut [f32]| {
+        let mut st = *state;
+        for s in 0 .. outp.len() {
+
+            let step = if st.tone_phase < 0_f32 {
+                0_f32
+            }
+            else if st.tone_phase < STEP_LEN {
+                smoothstep(0_f32, STEP_LEN, st.tone_phase)
+            }
+            else if st.tone_phase < 1_f32 {
+                1.0_f32
+            }
+            else if st.tone_phase < 1_f32 + STEP_LEN {
+                1_f32 - smoothstep(1_f32, 1_f32 + STEP_LEN, st.tone_phase)
+            }
+            else {
+                0_f32
+            };
+
+            let sample = if step > 0_f32 {
+                let modulation = 0.5_f32 * (1_f32 + st.mod_phase.sin());
+                step * st.phase.sin() * modulation
+            }
+            else {
+                0_f32
+            };
+
+            for c in 0 .. 1 {
+                outp[s + c] = sample;
+            }
+
+            st.phase += phase_pulse;
+            st.mod_phase += mod_phase_pulse;
+            st.tone_phase += 1_f32 / SAMPLE_RATE;
+
+            if st.phase > std::f32::consts::PI * 2_f32 {
+                st.phase -= std::f32::consts::PI * 2_f32;
+            }
+            if st.mod_phase > std::f32::consts::PI * 2_f32 {
+                st.mod_phase -= std::f32::consts::PI * 2_f32;
+            }
+            // overflow in the middle of the pause to avoid jump within step
+            if st.tone_phase > 2_f32 {
+                st.tone_phase -= 3_f32;
+            }
+        }
+        (*state) = st;
+        outp.len()
+    });
+
+    let params = cult::StreamParams::<f32>::new(SAMPLE_RATE as u32, 1, cult::ChannelLayout::Mono);
+    let min_latency = ctx.min_latency(params).expect("could not retrieve minimum latency");
+
+    let stm = cult::Stream::<f32>::new(
+        &ctx, "Sine",
+        None, None, None, Some(params),
+        min_latency, cb, Some(Box::new(cult::print_state_change))
+    ).expect("could not create audio stream");
+
+    stm.start().unwrap();
+
+    // 3 tones
+    thread::sleep(time::Duration::from_millis(7000 + (1000 as f32*STEP_LEN) as u64));
+
+    stm.stop().unwrap();
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,0 +1,169 @@
+
+extern crate libc;
+
+use libc::{c_void, c_uint, c_int, c_schar, c_long};
+
+pub const CUBEB_OK : c_int = 0;
+pub const CUBEB_ERROR : c_int = -1;
+pub const CUBEB_ERROR_INVALID_FORMAT : c_int = -2;
+pub const CUBEB_ERROR_INVALID_PARAMETER : c_int = -3;
+pub const CUBEB_ERROR_NOT_SUPPORTED : c_int = -4;
+pub const CUBEB_ERROR_DEVICE_UNAVAILABLE : c_int = -5;
+
+pub enum cubeb {}
+pub enum cubeb_stream {}
+
+pub type cubeb_sample_format = c_uint;
+
+pub type cubeb_devid = *const c_void;
+
+pub type cubeb_log_level = c_uint;
+
+pub type cubeb_channel_layout = c_uint;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct cubeb_stream_params {
+    pub format: cubeb_sample_format,
+    pub rate: u32,
+    pub channels: u32,
+    pub layout: cubeb_channel_layout,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct cubeb_device {
+    pub output_name: *mut c_schar,
+    pub input_name: *mut c_schar,
+}
+
+pub type cubeb_state = c_int;
+
+pub type cubeb_device_type = c_int;
+
+pub type cubeb_device_state = c_int;
+
+pub type cubeb_device_fmt = c_uint;
+
+pub type cubeb_device_pref = c_uint;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct cubeb_device_info {
+    pub devid:          cubeb_devid,
+    pub device_id:      *const c_schar,
+    pub friendly_name:  *const c_schar,
+    pub group_id:       *const c_schar,
+    pub vendor_name:    *const c_schar,
+
+    pub device_type:          cubeb_device_type,
+    pub state:          cubeb_device_state,
+    pub preferred:      cubeb_device_pref,
+
+    pub format:         cubeb_device_fmt,
+    pub default_format: cubeb_device_fmt,
+    pub max_channels:   u32,
+    pub default_rate:   u32,
+    pub max_rate:       u32,
+    pub min_rate:       u32,
+
+    pub latency_lo:     u32,
+    pub latency_hi:     u32,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct cubeb_device_collection {
+    pub device: *const cubeb_device_info,
+    pub count: usize,
+}
+
+
+pub type cubeb_data_callback = extern "C" fn (
+    *const cubeb_stream, *mut c_void,
+    *const c_void, *mut c_void, c_long) -> c_long;
+
+pub type cubeb_state_callback = extern "C" fn (
+    *const cubeb_stream, *mut c_void, cubeb_state);
+
+pub type cubeb_device_changed_callback = extern "C" fn (*mut c_void);
+
+pub type cubeb_device_collection_changed_callback = extern "C" fn (
+    *const cubeb, *mut c_void);
+
+//pub type cubeb_log_callback
+
+#[link(name = "cubeb")]
+extern {
+    pub fn cubeb_init (context: *mut *const cubeb, context_name: *const c_schar,
+                                             backend_name: *const c_schar) -> c_int;
+
+    pub fn cubeb_get_backend_id(context: *const cubeb) -> *const c_schar;
+
+    pub fn cubeb_get_max_channel_count(context: *const cubeb, max_channels: *mut u32)
+            -> c_int;
+
+
+    pub fn cubeb_get_min_latency(context: *const cubeb,
+                                 params: *const cubeb_stream_params,
+                                 latency_frames: *mut u32) -> c_int;
+
+    pub fn cubeb_get_preferred_sample_rate(context: *const cubeb, rate: *mut u32)
+            -> c_int;
+
+    pub fn cubeb_get_preferred_channel_layout(context: *const cubeb, layout: *mut cubeb_channel_layout) -> c_int;
+
+    pub fn cubeb_destroy(context: *const cubeb);
+
+    pub fn cubeb_stream_init(context: *const cubeb,
+                                stream: *mut *const cubeb_stream,
+                                stream_name: *const c_schar,
+                                input_device: cubeb_devid,
+                                input_stream_params: *mut cubeb_stream_params,
+                                output_device: cubeb_devid,
+                                output_stream_params: *mut cubeb_stream_params,
+                                latency_frames: u32,
+                                data_callback: Option<cubeb_data_callback>,
+                                state_callback: Option<cubeb_state_callback>,
+                                user_ptr: *mut c_void) -> c_int;
+
+    pub fn cubeb_stream_destroy(stream: *const cubeb_stream);
+
+    pub fn cubeb_stream_start(stream: *const cubeb_stream) -> c_int;
+
+    pub fn cubeb_stream_stop(stream: *const cubeb_stream) -> c_int;
+
+    pub fn cubeb_stream_reset_default_device(stream: *const cubeb_stream) -> c_int;
+
+    pub fn cubeb_stream_get_position(stream: *const cubeb_stream, position: *mut u64) -> c_int;
+
+    pub fn cubeb_stream_get_latency(stream: *const cubeb_stream, latency: *mut u32) -> c_int;
+
+    pub fn cubeb_stream_set_volume(stream: *const cubeb_stream, volume: f32) -> c_int;
+
+    pub fn cubeb_stream_set_panning(stream: *const cubeb_stream, panning: f32) -> c_int;
+
+    pub fn cubeb_stream_get_current_device(stream: *const cubeb_stream,
+                                           device: *mut *const cubeb_device) -> c_int;
+
+    pub fn cubeb_stream_device_destroy(stream: *const cubeb_stream,
+                                       devices: *mut cubeb_device) -> c_int;
+
+    pub fn cubeb_stream_register_device_changed_callback(stream: *const cubeb_stream,
+                                                         callback: cubeb_device_changed_callback) -> c_int;
+
+    pub fn cubeb_enumerate_devices(context: *const cubeb,
+                                   devtype: cubeb_device_type,
+                                   collection: *mut cubeb_device_collection) -> c_int;
+
+    pub fn cubeb_device_collection_destroy(context: *const cubeb,
+                                           collection: *mut cubeb_device_collection) -> c_int;
+
+    pub fn cubeb_register_device_collection_changed(context: *const cubeb,
+                                                    devtype: cubeb_device_type,
+                                                    callback: cubeb_device_collection_changed_callback,
+                                                    user_ptr: *mut c_void) -> c_int;
+
+    // pub fn cubeb_set_log_callback(log_level: cubeb_log_level,
+    //                               callback: cubeb_log_callback) -> c_int;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,287 +1,717 @@
+
+#![allow(non_camel_case_types)]
+
 extern crate libc;
 #[macro_use]
-#[cfg(feature = "plugins")]
-extern crate heapsize;
+extern crate bitflags;
+// #[macro_use]
+// #[cfg(feature = "plugins")]
+// extern crate heapsize;
 
-use libc::{c_void, c_uint, c_int};
+use libc::{c_int, c_void, c_long};
+use std::ffi::{CStr, CString};
+use std::mem::transmute;
 use std::ptr;
-use std::mem::{transmute};
-use std::ffi::CString;
-use std::ffi::CStr;
+use std::slice;
+use std::result;
+use std::marker::PhantomData;
+use std::boxed::Box;
 
-pub type CubebPtr = *mut c_void;
-pub type CubebStreamPtr = *mut c_void;
-pub type CubebDataCallback = extern "C" fn(CubebStreamPtr,
-                                             *mut libc::c_void,
-                                             *mut libc::c_void,
-                                             libc::c_long) -> libc::c_long;
-pub type CubebStateCallback = extern "C" fn(CubebStreamPtr,
-                                              *mut libc::c_void,
-                                              CubebState);
+pub mod ffi;
+use ffi::*;
 
-pub type CubebSampleFormat = c_uint;
-pub const CUBEB_SAMPLE_S16LE: u32 = 0_u32;
-pub const CUBEB_SAMPLE_S16BE: u32 = 1_u32;
-pub const CUBEB_SAMPLE_FLOAT32LE: u32 = 2_u32;
-pub const CUBEB_SAMPLE_FLOAT32BE: u32 = 3_u32;
-pub const CUBEB_SAMPLE_S16NE: u32 = CUBEB_SAMPLE_S16LE;
-pub const CUBEB_SAMPLE_FLOAT32NE: u32 = CUBEB_SAMPLE_FLOAT32LE;
-
-pub type CubebState = c_uint;
-pub static CUBEB_STATE_STARTED: u32 = 0_u32; /**< Stream started. */
-pub static CUBEB_STATE_STOPPED: u32 = 1_u32; /**< Stream stopped. */
-pub static CUBEB_STATE_DRAINED: u32 = 2_u32; /**< Stream drained. */
-pub static CUBEB_STATE_ERROR: u32 = 3_u32;   /**< Stream disabled due to error. */
-
-pub type CubebErrors = c_int;
-/* Success. */
-pub static CUBEB_OK: i32 = 0_i32;
-/* Unclassified error. */
-pub static CUBEB_ERROR: i32 = -1_i32;
-/* Unsupported CubebStreamParams requested. */
-pub static CUBEB_ERROR_INVALID_FORMAT: i32 = -2_i32;
-/* Invalid parameter specified. */
-pub static CUBEB_ERROR_INVALID_PARAMETER: i32 = -3_i32;
-
-
-#[repr(C)]
-pub struct CubebStreamParams {
-  format: CubebSampleFormat,
-  rate: libc::uint32_t,
-  channels: libc::uint32_t,
+#[derive(Debug, Copy, Clone)]
+pub enum Error {
+    Undefined           = -1,
+    InvalidFormat       = -2,
+    InvalidParameter    = -3,
+    NotSupported        = -4,
+    DeviceUnavailable   = -5,
 }
 
-#[link(name = "cubeb")]
-extern {
-  fn cubeb_init(context: &mut CubebPtr, context_name: *const u8) -> libc::c_int;
-  fn cubeb_get_backend_id(context: CubebPtr) -> *const libc::c_char;
-  fn cubeb_get_max_channel_count(context: CubebPtr,
-                                 max_channels: *mut libc::uint32_t) -> libc::c_int;
-  fn cubeb_get_min_latency(context: CubebPtr,
-                           params: CubebStreamParams,
-                           latency_ms: *mut libc::uint32_t) -> libc::c_int;
-  fn cubeb_get_preferred_sample_rate(context: CubebPtr,
-                                     rate: *mut libc::uint32_t) -> libc::c_int;
-  fn cubeb_destroy(context: CubebPtr);
-  fn cubeb_stream_init(context: CubebPtr,
-                       stream: *mut CubebStreamPtr,
-                       stream_name: *const u8,
-                       stream_params: CubebStreamParams,
-                       latency: libc::c_uint,
-                       data_callback: CubebDataCallback,
-                       state_callback: CubebStateCallback,
-                       user_ptr: *const AudioStream) -> libc::c_int;
-
-  fn cubeb_stream_destroy(stream: CubebStreamPtr);
-  fn cubeb_stream_start(stream: CubebStreamPtr) -> libc::c_int;
-  fn cubeb_stream_stop(stream: CubebStreamPtr) -> libc::c_int;
-  fn cubeb_stream_get_position(stream: CubebStreamPtr,
-                               position: *mut libc::uint64_t) -> libc::c_int;
-  fn cubeb_stream_get_latency(stream: CubebStreamPtr,
-                              latency: *mut libc::uint32_t) -> libc::c_int;
+impl From<c_int> for Error {
+    fn from (code: c_int) -> Self {
+        debug_assert!(code < 0);
+        match code {
+            CUBEB_ERROR_INVALID_FORMAT      => Error::InvalidFormat,
+            CUBEB_ERROR_INVALID_PARAMETER   => Error::InvalidParameter,
+            CUBEB_ERROR_NOT_SUPPORTED       => Error::NotSupported,
+            CUBEB_ERROR_DEVICE_UNAVAILABLE  => Error::DeviceUnavailable,
+            _                               => Error::Undefined,
+        }
+    }
 }
 
-pub type DataCallback = Box<FnMut(&mut [f32]) -> i32>;
+pub type Result<T> = result::Result<T, Error>;
 
-fn noopcallback(buffer: &mut [f32]) -> i32
+
+pub type DataCallback<T> = Box<FnMut(&[T], &mut [T]) -> usize>;
+pub type StateCallback = Box<FnMut(State)>;
+pub type DeviceChangedCallback = Box<FnMut()>;
+
+
+#[derive(Debug, Copy, Clone)]
+#[repr(u8)]
+pub enum SampleFormat {
+    Signed16LE  = 0,
+    Signed16BE  = 1,
+    Float32LE   = 2,
+    Float32BE   = 3,
+}
+
+#[cfg(target_endian = "little")]
+pub fn native_signed16() -> SampleFormat {
+    SampleFormat::Signed16LE
+}
+
+#[cfg(target_endian = "big")]
+pub fn native_signed16() -> SampleFormat {
+    SampleFormat::Signed16BE
+}
+
+#[cfg(target_endian = "little")]
+pub fn native_float32() -> SampleFormat {
+    SampleFormat::Float32LE
+}
+
+#[cfg(target_endian = "big")]
+pub fn native_float32() -> SampleFormat {
+    SampleFormat::Float32BE
+}
+
+impl Into<cubeb_sample_format> for SampleFormat
 {
-  buffer.len() as i32
+    fn into(self) -> cubeb_sample_format {
+        self as cubeb_sample_format
+    }
 }
 
-pub struct AudioStream {
-  rate: u32,
-  format: CubebSampleFormat,
-  channels: u32,
-  stream: CubebStreamPtr,
-  ctx: std::rc::Rc<CubebContext>,
-  callback: DataCallback
-}
-
-impl AudioStream {
-  pub fn new(ctx: std::rc::Rc<CubebContext>) -> AudioStream
-  {
-    return AudioStream {
-      rate: 0,
-      format: CUBEB_SAMPLE_FLOAT32NE,
-      channels: 0,
-      stream: ptr::null_mut(),
-      ctx: ctx.clone(),
-      callback: Box::new(|_| 0)
-    };
-  }
-  pub fn init(&mut self,
-                 rate: u32,
-                 channels: u32,
-                 format: CubebSampleFormat,
-                 callback: DataCallback,
-                 name: &str)
-  {
-    let rv;
-    let cubeb_format = CubebStreamParams {
-       format: format,
-       rate: rate,
-       channels: channels
-    };
-
-    unsafe {
-      self.rate = rate;
-      self.format = format;
-      self.channels = channels;
-      self.callback = callback;
-
-      let cstr = CString::new(name).unwrap();
-
-      rv = cubeb_stream_init(self.ctx.get(),
-                             transmute::<&mut CubebStreamPtr,*mut CubebStreamPtr>(&mut self.stream),
-                             cstr.as_bytes_with_nul().as_ptr(),
-                             cubeb_format,
-                             40,
-                             refill_glue,
-                             state,
-                             self) == 0;
-      if !rv {
-        println!("Error.");
-      }
-    }
-  }
-  pub fn start(&self) {
-    unsafe {
-      cubeb_stream_start(self.stream);
-    }
-  }
-  pub fn stop(&self) {
-    unsafe {
-      cubeb_stream_stop(self.stream);
-    }
-  }
-  pub fn clock(&self) -> u64 {
-    let mut pos: libc::uint64_t = 0;
-    let rv;
-    unsafe {
-      rv = cubeb_stream_get_position(self.stream, &mut pos) == CUBEB_OK;
-    }
-    if !rv {
-      println!("clock() failed.");
-      return 0
-    }
-    pos
-  }
-  pub fn latency(&self) -> u32 {
-    let mut lat: libc::uint32_t = 0;
-    let rv;
-    unsafe {
-      rv = cubeb_stream_get_latency(self.stream, &mut lat) == CUBEB_OK;
-    }
-    if !rv {
-      println!("latency() failed.");
-      return 0
-    }
-    lat
-  }
-}
-
-impl Drop for AudioStream {
-  fn drop(&mut self) {
-    unsafe {
-      println!("stream destroy.");
-      cubeb_stream_destroy(self.stream);
-    }
-  }
-}
-
-extern fn refill_glue(stm: CubebStreamPtr,
-                      user: *mut c_void,
-                      buffer: *mut c_void,
-                      nframes: libc::c_long) -> libc::c_long
+pub trait Sample
 {
-  let fbuf: &mut[f32];
-  let stream: *mut AudioStream;
-  unsafe {
-    stream = transmute(user as *mut AudioStream);
-    fbuf = transmute((buffer as *mut f32, nframes * (*stream).channels as libc::c_long));
-    ((*stream).callback)(fbuf);
-  }
-
-  nframes
+    fn format() -> SampleFormat;
+    fn data_cb_ffi() -> cubeb_data_callback;
 }
 
-extern fn state(stm: CubebStreamPtr,
-                user: *mut c_void,
-                state: CubebState)
+impl Sample for i16 {
+    fn format() -> SampleFormat {
+        native_signed16()
+    }
+    fn data_cb_ffi() -> cubeb_data_callback {
+        data_callback_i16
+    }
+}
+
+impl Sample for f32 {
+    fn format() -> SampleFormat {
+        native_float32()
+    }
+    fn data_cb_ffi() -> cubeb_data_callback {
+        data_callback_f32
+    }
+}
+
+
+#[derive(Debug, Copy, Clone)]
+#[repr(u8)]
+pub enum LogLevel {
+    Disabled    = 0,
+    Normal      = 1,
+    Verbose     = 2,
+}
+
+#[derive(Debug, Copy, Clone)]
+#[repr(u8)]
+pub enum ChannelLayout {
+    Undefined       = 0,
+    DualMono        = 1,
+    DualMono_LFE    = 2,
+    Mono            = 3,
+    Mono_LFE        = 4,
+    Stereo          = 5,
+    Stereo_LFE      = 6,
+    F3              = 7,
+    F3_LFE          = 8,
+    F2_1            = 9,
+    F2_1_LFE        = 10,
+    F3_1            = 11,
+    F3_1_LFE        = 12,
+    F2_2            = 13,
+    F2_2_LFE        = 14,
+    F3_2            = 15,
+    F3_2_LFE        = 16,
+    F3_R3_LFE       = 17,
+    F3_4_LFE        = 18,
+    Max             = 19,
+}
+
+impl Into<cubeb_channel_layout> for ChannelLayout {
+    fn into(self) -> cubeb_channel_layout {
+        self as cubeb_channel_layout
+    }
+}
+
+impl From<cubeb_channel_layout> for ChannelLayout {
+    fn from(layout: cubeb_channel_layout) -> ChannelLayout {
+        unsafe { transmute( layout as u8 ) }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+#[repr(u8)]
+pub enum State {
+    Started = 0,
+    Stopped = 1,
+    Drained = 2,
+    Error   = 3,
+}
+
+impl From<cubeb_state> for State {
+    fn from(state: cubeb_state) -> State {
+        unsafe { transmute( state as u8 ) }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+#[repr(u8)]
+pub enum DeviceType {
+    Unknown = 0,
+    Input   = 1,
+    Output  = 2,
+}
+
+impl Into<cubeb_device_type> for DeviceType
 {
-  println!("state: {}", state);
+    fn into(self) -> cubeb_device_type {
+        self as cubeb_device_type
+    }
 }
 
-
-pub struct CubebContext {
-  ctx: CubebPtr
-}
-
-impl CubebContext
+impl From<cubeb_device_type> for DeviceType
 {
-  pub fn new(name: &str) -> CubebContext {
-    let mut cubeb: CubebPtr = ptr::null_mut();
-    let rv;
-    let cstr = CString::new(name).unwrap();
-    unsafe {
-      rv = cubeb_init(transmute(&mut cubeb), cstr.as_bytes_with_nul().as_ptr()) == 0;
+    fn from(dt: cubeb_device_type) -> Self {
+        unsafe { transmute( dt as u8 ) }
     }
-    if !rv {
-      println!("cubeb_init failed.");
-    }
-    CubebContext {
-      ctx: cubeb
-    }
-  }
-  fn get(&self) -> CubebPtr {
-    self.ctx
-  }
-  pub fn backend_id(&self) ->  &'static str {
-    let chars : *const libc::c_char;
-    unsafe {
-      chars = cubeb_get_backend_id(self.get());
-      let slice = CStr::from_ptr(chars).to_bytes();
-      return std::str::from_utf8(slice).unwrap();
-    }
-  }
-  pub fn max_channel_count(&self) -> u32 {
-    let mut max_channel_count: u32 = 0;
-    unsafe {
-      if cubeb_get_max_channel_count(self.get(), &mut max_channel_count) != CUBEB_OK {
-        println!("failed.");
-      }
-    }
-    max_channel_count
-  }
-  pub fn min_latency(&self, params: CubebStreamParams) -> u32 {
-    let mut min_latency: u32 = 0;
-    unsafe {
-      if cubeb_get_min_latency(self.get(), params, &mut min_latency) !=
-        CUBEB_OK {
-        println!("failed.");
-      }
-    }
-    min_latency
-  }
-  pub fn preferred_sample_rate(&self) -> u32 {
-    let mut sr : u32 = 0;
-    unsafe {
-      if cubeb_get_preferred_sample_rate(self.get(), &mut sr) != CUBEB_OK {
-        println!("failed.");
-      }
-    }
-    sr
-  }
 }
 
-impl Drop for CubebContext {
-  fn drop(&mut self) {
-    unsafe {
-      println!("Cubeb_destroy.");
-      cubeb_destroy(self.ctx);
-    }
-  }
+#[derive(Debug, Copy, Clone)]
+#[repr(u8)]
+pub enum DeviceState {
+    Disabled,
+    Unplugged,
+    Enabled,
 }
 
-#[cfg(feature = "plugins")]
-known_heap_size!(0, AudioStream);
+impl Into<cubeb_device_state> for DeviceState
+{
+    fn into(self) -> cubeb_device_state {
+        self as cubeb_device_state
+    }
+}
+
+impl From<cubeb_device_state> for DeviceState
+{
+    fn from(dt: cubeb_device_state) -> Self {
+        unsafe { transmute( dt as u8 ) }
+    }
+}
+
+bitflags!{
+    pub struct DeviceFmt : u16 {
+        const DEVICE_FMT_S16LE  = 0x0010;
+        const DEVICE_FMT_S16BE  = 0x0020;
+        const DEVICE_FMT_F32LE  = 0x1000;
+        const DEVICE_FMT_F32BE  = 0x2000;
+
+        const DEVICE_FMT_S16_MASK = DEVICE_FMT_S16LE.bits |
+                                    DEVICE_FMT_S16BE.bits;
+        const DEVICE_FMT_F32_MASK = DEVICE_FMT_F32LE.bits |
+                                    DEVICE_FMT_F32BE.bits;
+        const DEVICE_FMT_ALL = DEVICE_FMT_S16_MASK.bits |
+                               DEVICE_FMT_F32_MASK.bits;
+    }
+}
+
+#[cfg(target_endian = "little")]
+pub const DEVICE_FMT_S16NE: DeviceFmt = DEVICE_FMT_S16LE;
+#[cfg(target_endian = "little")]
+pub const DEVICE_FMT_F32NE: DeviceFmt = DEVICE_FMT_F32LE;
+#[cfg(target_endian = "big")]
+pub const DEVICE_FMT_S16NE: DeviceFmt = DEVICE_FMT_S16BE;
+#[cfg(target_endian = "big")]
+pub const DEVICE_FMT_F32NE: DeviceFmt = DEVICE_FMT_F32BE;
+
+
+bitflags!{
+    pub struct DevicePref : u8 {
+        const DEVICE_PREF_NONE            = 0x00;
+        const DEVICE_PREF_MULTIMEDIA      = 0x01;
+        const DEVICE_PREF_VOICE           = 0x02;
+        const DEVICE_PREF_NOTIFICATION    = 0x04;
+        const DEVICE_PREF_ALL             = 0x0F;
+    }
+}
+
+
+#[derive(Debug)]
+pub struct Context {
+    native: *const cubeb,
+}
+
+impl Context {
+    pub fn new(context_name: &str, backend_name: Option<&str>) -> Result<Context> {
+        let mut ctx = ptr::null();
+        let context_name = CString::new(context_name).unwrap();
+        let backend_name = backend_name.map(|s| CString::new(s).unwrap());
+        let res = unsafe {
+            cubeb_init(
+                &mut ctx as *mut *const cubeb,
+                context_name.as_ptr(),
+                backend_name.map_or(ptr::null(), |s| s.as_ptr())
+            )
+        };
+        match res {
+            CUBEB_OK => {
+                Ok( Context { native: ctx } )
+            },
+            _ => { Err( Error::from(res) ) }
+        }
+    }
+
+    pub fn backend_id(&self) -> &str {
+        let bid = unsafe {
+            CStr::from_ptr(cubeb_get_backend_id(self.native))
+        };
+        bid.to_str().expect("Cubeb::backend_id is invalid UTF-8")
+    }
+
+    pub fn enumerate_devices(&self, devtype: DeviceType)
+            -> Result<DeviceCollection> {
+        let mut col = cubeb_device_collection {
+            device: ptr::null(),
+            count: 0,
+        };
+        let res = unsafe {
+            cubeb_enumerate_devices(self.native, devtype.into(), &mut col)
+        };
+        match res {
+            CUBEB_OK => {
+                Ok(DeviceCollection {
+                    native: col,
+                    // ctx: Weak::upgrade(&self.weak_me.borrow()).unwrap(),
+                    ctx: self,
+                })
+            }
+            _ => { Err( Error::from(res) ) }
+        }
+    }
+
+    pub fn max_channel_count(&self) -> Result<u32> {
+        let mut count = 0;
+        let res = unsafe {
+            cubeb_get_max_channel_count(self.native, &mut count as *mut u32)
+        };
+        match res {
+            CUBEB_OK => { Ok(count) },
+            _ => { Err( Error::from(res) ) }
+        }
+    }
+
+    pub fn min_latency<T: Sample>(&self, params: StreamParams<T>) -> Result<u32> {
+        let mut latency = 0;
+        let params = params.into();
+        let res = unsafe {
+            cubeb_get_min_latency(self.native,
+                        &params as *const _,
+                        &mut latency as *mut _)
+        };
+        match res {
+            CUBEB_OK => { Ok(latency) },
+            _ => { Err( Error::from(res) ) }
+        }
+    }
+
+    pub fn preferred_sample_rate(&self) -> Result<u32> {
+        let mut rate = 0;
+        let res = unsafe {
+            cubeb_get_preferred_sample_rate(self.native, &mut rate)
+        };
+        match res {
+            CUBEB_OK => { Ok(rate) },
+            _ => { Err( Error::from(res) ) }
+        }
+    }
+
+    pub fn preferred_channel_layout(&self) -> Result<ChannelLayout> {
+        let mut layout = 0;
+        let res = unsafe {
+            cubeb_get_preferred_channel_layout(self.native, &mut layout)
+        };
+        match res {
+            CUBEB_OK => { Ok(ChannelLayout::from(layout)) },
+            _ => { Err( Error::from(res) ) }
+        }
+    }
+}
+
+impl Drop for Context {
+    fn drop(&mut self) {
+        unsafe { cubeb_destroy(self.native); }
+    }
+}
+
+
+pub enum DevId {}
+
+
+#[derive(Debug)]
+pub struct DeviceInfo<'a> {
+    native: *const cubeb_device_info,
+    phantom: PhantomData<&'a cubeb_device_info>,
+}
+
+impl<'a> DeviceInfo<'a>
+{
+    pub fn devid(&self) -> &'a DevId {
+        unsafe { transmute( (*self.native).devid ) }
+    }
+
+    pub fn device_id(&self) -> &str {
+        let slice = unsafe {
+            CStr::from_ptr( (*self.native).device_id )
+        };
+        slice.to_str().expect("UTF-8 error")
+    }
+
+    pub fn friendly_name(&self) -> &str {
+        let slice = unsafe {
+            CStr::from_ptr( (*self.native).friendly_name )
+        };
+        slice.to_str().expect("UTF-8 error")
+    }
+
+    pub fn group_id(&self) -> &str {
+        let slice = unsafe {
+            CStr::from_ptr( (*self.native).group_id )
+        };
+        slice.to_str().expect("UTF-8 error")
+    }
+
+    pub fn vendor_name(&self) -> &str {
+        let slice = unsafe {
+            CStr::from_ptr( (*self.native).vendor_name )
+        };
+        slice.to_str().expect("UTF-8 error")
+    }
+
+
+    pub fn device_type(&self) -> DeviceType {
+        DeviceType::from( unsafe { (*self.native).device_type } )
+    }
+
+    pub fn state(&self) -> DeviceState {
+        DeviceState::from( unsafe { (*self.native).state } )
+    }
+
+    pub fn preferred(&self) -> DevicePref {
+        DevicePref {
+            bits: unsafe { (*self.native).preferred as u8 }
+        }
+    }
+
+
+    pub fn format(&self) -> DeviceFmt {
+        DeviceFmt {
+            bits: unsafe { (*self.native).format as u16 }
+        }
+    }
+
+    pub fn default_format(&self) -> DeviceFmt {
+        DeviceFmt {
+            bits: unsafe { (*self.native).default_format as u16 }
+        }
+    }
+
+    pub fn max_channels(&self) -> u32 {
+        unsafe { (*self.native).max_channels }
+    }
+
+    pub fn default_rate(&self) -> u32 {
+        unsafe { (*self.native).default_rate }
+    }
+
+    pub fn max_rate(&self) -> u32 {
+        unsafe { (*self.native).max_rate }
+    }
+
+    pub fn min_rate(&self) -> u32 {
+        unsafe { (*self.native).min_rate }
+    }
+
+
+    pub fn latency_lo(&self) -> u32 {
+        unsafe { (*self.native).latency_lo }
+    }
+
+    pub fn latency_hi(&self) -> u32 {
+        unsafe { (*self.native).latency_hi }
+    }
+}
+
+#[derive(Debug)]
+pub struct DeviceCollection<'a> {
+    ctx: &'a Context,
+    native: cubeb_device_collection,
+}
+
+impl<'a> Iterator for DeviceCollection<'a> {
+    type Item = DeviceInfo<'a>;
+    fn next (&mut self) -> Option<Self::Item> {
+        match self.native.count {
+            0 => None,
+            _ => {
+                self.native.count -= 1;
+                unsafe {
+                    let res = DeviceInfo {
+                        native: self.native.device,
+                        phantom: PhantomData,
+                    };
+                    self.native.device = self.native.device.offset(1);
+                    Some (res)
+                }
+            }
+        }
+    }
+}
+
+impl<'a> Drop for DeviceCollection<'a> {
+    fn drop (&mut self) {
+        unsafe {
+            cubeb_device_collection_destroy(self.ctx.native, &mut self.native);
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct StreamParams<T: Sample> {
+    rate: u32,
+    channels: u32,
+    layout: ChannelLayout,
+    phantom: PhantomData<T>,
+}
+
+impl<T: Sample> StreamParams<T> {
+    pub fn new (rate: u32, channels: u32, layout: ChannelLayout) -> StreamParams<T> {
+        StreamParams {
+            rate: rate, channels: channels, layout: layout, phantom: PhantomData
+        }
+    }
+}
+
+impl<T: Sample> Into<cubeb_stream_params> for StreamParams<T> {
+    fn into(self) -> cubeb_stream_params {
+        cubeb_stream_params {
+            format: T::format().into(),
+            rate: self.rate,
+            channels: self.channels,
+            layout: self.layout.into(),
+        }
+    }
+}
+
+
+pub struct Stream<T: Sample> {
+    native: *const cubeb_stream,
+    data: Box<StreamData<T>>,
+}
+
+struct StreamData<T: Sample> {
+    data_cb: DataCallback<T>,
+    state_cb: Option<StateCallback>,
+    in_channels: u32,
+    out_channels: u32,
+}
+
+impl<T: Sample> Stream<T> {
+    pub fn new(ctx: &Context, stream_name: &str,
+               in_device: Option<&DevId>, in_params: Option<StreamParams<T>>,
+               out_device: Option<&DevId>, out_params: Option<StreamParams<T>>,
+               latency_frames: u32, data_cb: DataCallback<T>,
+               state_cb: Option<StateCallback>) -> Result<Stream<T>> {
+        let mut stm = ptr::null();
+
+        let nat_state_cb: Option<cubeb_state_callback> = match state_cb.as_ref() {
+            Some(_) => Some(state_callback_cb),
+            None => Some(state_callback_noop),
+        };
+        let mut data = Box::new(StreamData {
+            data_cb: data_cb,
+            state_cb: state_cb,
+            in_channels: in_params.as_ref().map_or(0, |p| p.channels),
+            out_channels: out_params.as_ref().map_or(0, |p| p.channels),
+        });
+
+        let stream_name = CString::new(stream_name).unwrap();
+        let in_params: Option<cubeb_stream_params> = in_params.map(|p| p.into());
+        let out_params: Option<cubeb_stream_params> = out_params.map(|p| p.into());
+
+        let res = unsafe {
+            cubeb_stream_init(ctx.native, &mut stm, stream_name.as_ptr(),
+                transmute(in_device), transmute(in_params.as_ref()),
+                transmute(out_device), transmute(out_params.as_ref()),
+                latency_frames, Some(T::data_cb_ffi()), nat_state_cb,
+                &mut *data as *mut StreamData<T> as *mut c_void
+            )
+        };
+        match res {
+            CUBEB_OK => Ok(Stream {
+                native: stm,
+                data: data,
+            }),
+            _ => Err( Error::from(res) )
+        }
+    }
+
+    pub fn start(&self) -> Result<()> {
+        let res = unsafe {
+            cubeb_stream_start(self.native)
+        };
+        match res {
+            CUBEB_OK => Ok(()),
+            _ => Err(Error::from(res)),
+        }
+    }
+
+    pub fn stop(&self) -> Result<()> {
+        let res = unsafe {
+            cubeb_stream_stop(self.native)
+        };
+        match res {
+            CUBEB_OK => Ok(()),
+            _ => Err(Error::from(res)),
+        }
+    }
+
+    pub fn reset_default_device(&self) -> Result<()> {
+        let res = unsafe {
+            cubeb_stream_reset_default_device(self.native)
+        };
+        match res {
+            CUBEB_OK => Ok(()),
+            _ => Err(Error::from(res)),
+        }
+    }
+
+    pub fn position(&self) -> Result<u64> {
+        let mut val = 0;
+        let res = unsafe {
+            cubeb_stream_get_position(self.native, &mut val)
+        };
+        match res {
+            CUBEB_OK => Ok(val),
+            _ => Err(Error::from(res)),
+        }
+    }
+
+    pub fn latency(&self) -> Result<u32> {
+        let mut val = 0;
+        let res = unsafe {
+            cubeb_stream_get_latency(self.native, &mut val)
+        };
+        match res {
+            CUBEB_OK => Ok(val),
+            _ => Err(Error::from(res)),
+        }
+    }
+
+    pub fn set_volume(&self, volume: f32) -> Result<()> {
+        let res = unsafe {
+            cubeb_stream_set_volume(self.native, volume)
+        };
+        match res {
+            CUBEB_OK => Ok(()),
+            _ => Err(Error::from(res)),
+        }
+    }
+
+    pub fn set_panning(&self, panning: f32) -> Result<()> {
+        let res = unsafe {
+            cubeb_stream_set_panning(self.native, panning)
+        };
+        match res {
+            CUBEB_OK => Ok(()),
+            _ => Err(Error::from(res)),
+        }
+    }
+}
+
+impl<T: Sample> Drop for Stream<T> {
+    fn drop(&mut self) {
+        unsafe { cubeb_stream_destroy(self.native); }
+    }
+}
+
+
+pub fn print_state_change(state: State) {
+    match state {
+        State::Started => println!("stream started"),
+        State::Stopped => println!("stream stopped"),
+        State::Drained => println!("stream drained"),
+        State::Error => println!("stream error"),
+    }
+
+}
+
+
+extern fn data_callback_i16(_stm: *const cubeb_stream,
+                            user: *mut c_void,
+                            in_buf: *const c_void,
+                            out_buf: *mut c_void,
+                            nframes: c_long) -> c_long {
+    unsafe {
+        let data: &mut StreamData<i16> = transmute(user);
+        let ibuf: &[i16] = slice::from_raw_parts(
+            in_buf as *const i16, nframes as usize * data.in_channels as usize
+        );
+        let obuf: &mut [i16] = slice::from_raw_parts_mut(
+            out_buf as *mut i16, nframes as usize * data.out_channels as usize
+        );
+
+        (data.data_cb)(ibuf, obuf) as c_long
+    }
+}
+
+extern fn data_callback_f32(_stm: *const cubeb_stream,
+                            user: *mut c_void,
+                            in_buf: *const c_void,
+                            out_buf: *mut c_void,
+                            nframes: c_long) -> c_long {
+    unsafe {
+        let data: &mut StreamData<f32> = transmute(user);
+        let ibuf: &[f32] = slice::from_raw_parts(
+            in_buf as *const f32, nframes as usize * data.in_channels as usize
+        );
+        let obuf: &mut [f32] = slice::from_raw_parts_mut(
+            out_buf as *mut f32, nframes as usize * data.out_channels as usize
+        );
+
+        (data.data_cb)(ibuf, obuf) as c_long
+    }
+}
+
+extern fn state_callback_noop(_stm: *const cubeb_stream,
+                               _user: *mut c_void,
+                               _state: cubeb_state)
+{}
+
+extern fn state_callback_cb(_stm: *const cubeb_stream,
+                             user: *mut c_void,
+                             state: cubeb_state) {
+    unsafe {
+        let data: &mut StreamData<f32> = transmute(user);
+        (*data.state_cb.as_mut().unwrap())(State::from(state));
+    }
+}
+
+
+// #[cfg(feature = "plugins")]
+// known_heap_size!(0, AudioStream);


### PR DESCRIPTION
Hi,

This PR is a first step for me in contributing to servo's webaudio.
This is an adaption of cult to follow cubeb's master branch. Main motivation is to have input available in cult.
 - use cmake for `build-cubeb` feature
 - FFI module that has the whole C API
 - safe wrapper (`lib.rs`) completely rewritten and full featured vs C
 - changed a few names for consistency with C (CubebContext -> Context, AudioStream -> Stream)
 - a few examples

I dropped the `Rc<Context>` stuff. It would only be needed for `DeviceCollection`, but it's easy to borrow a context for the lifetime of a collection. `Stream` does not need to borrow `Context`.
I left the log API aside as I can't deal directly with the C vararg stuff. Could be solved with some C glue code.